### PR TITLE
[feature]: 역할(Role)에 따른 회원가입 분기 및 승인 처리 로직 구현

### DIFF
--- a/src/main/java/com/fourirbnb/auth/application/mapper/AuthDtoMapper.java
+++ b/src/main/java/com/fourirbnb/auth/application/mapper/AuthDtoMapper.java
@@ -1,13 +1,14 @@
 package com.fourirbnb.auth.application.mapper;
 
+import com.fourirbnb.auth.domain.model.ApprovalStatus;
 import com.fourirbnb.auth.domain.model.Role;
 import com.fourirbnb.auth.presentation.dto.CreateUserInternalRequest;
-import com.fourirbnb.auth.presentation.dto.SignUpAuthRequest;
+import com.fourirbnb.auth.presentation.dto.SignUpUserRequest;
 
 public class AuthDtoMapper {
 
-  public static CreateUserInternalRequest toCreateInternalDto(SignUpAuthRequest request,
-      String encodedPassword) {
+  public static CreateUserInternalRequest toCreateInternalDto(SignUpUserRequest request,
+      String encodedPassword, Role role) {
     return new CreateUserInternalRequest(
         request.getEmail(),
         encodedPassword,
@@ -15,7 +16,10 @@ public class AuthDtoMapper {
         request.getUsername(),
         request.getPhone(),
         request.getSlackId(),
-        Role.CUSTOMER
+        role,
+        ApprovalStatus.APPROVED
+
     );
   }
+  
 }

--- a/src/main/java/com/fourirbnb/auth/application/service/AuthService.java
+++ b/src/main/java/com/fourirbnb/auth/application/service/AuthService.java
@@ -2,12 +2,14 @@ package com.fourirbnb.auth.application.service;
 
 
 import com.fourirbnb.auth.application.mapper.AuthDtoMapper;
+import com.fourirbnb.auth.domain.model.Role;
 import com.fourirbnb.auth.infrastructure.UserFeignClient;
 import com.fourirbnb.auth.presentation.dto.ChangePasswordRequest;
 import com.fourirbnb.auth.presentation.dto.CreateUserInternalRequest;
 import com.fourirbnb.auth.presentation.dto.LoginUserRequest;
 import com.fourirbnb.auth.presentation.dto.LoginUserResponse;
-import com.fourirbnb.auth.presentation.dto.SignUpAuthRequest;
+import com.fourirbnb.auth.presentation.dto.SignUpUserRequest;
+import com.fourirbnb.auth.presentation.dto.UpdatePasswordRequest;
 import com.fourirbnb.auth.presentation.dto.UserInternalResponse;
 import com.fourirbnb.common.exception.InternalServerException;
 import com.fourirbnb.common.exception.InvalidParameterException;
@@ -40,26 +42,58 @@ public class AuthService {
 
   private final SecretKey secretKey;
 
+  /*
+   권한(Role)에 따라 서비스 로직을 분리하는 것이 구조적으로는 맞지만,
+   구현 복잡도와 프로젝트 리소스를 고려해
+   하나의 메서드 내에서 역할별 분기 처리로 간소화하여 진행하였습니다.
 
-  public void signUp(SignUpAuthRequest request) {
+   추후 확장 시 각 역할(Role)에 따른 서비스/로직 분리를 고려할 수 있습니다.
+ */
+  public void signUp(SignUpUserRequest request, Role role) {
+
     String hashedPassword = passwordEncoder.encode(request.getPassword());
 
     CreateUserInternalRequest feignRequest = AuthDtoMapper.toCreateInternalDto(request,
-        hashedPassword);
+        hashedPassword, role);
+
     //상태코드로 분기구분
     try {
-      userFeignClient.userSignUp(feignRequest);
+      // 조건문으로 CUSTOMER MASTER 일때 그냥 바로 저장 HOST MANAGER 일때 Staging 이동
+      if (role == Role.CUSTOMER) {
+        userFeignClient.userSignUp(feignRequest);
+      } else if (role == Role.HOST || role == Role.MANAGER) {
+        userFeignClient.saveStagingRequest(feignRequest);
+      } else if (role == Role.MASTER) {
+        userFeignClient.adminSignUp(feignRequest);
+      } else {
+        throw new InvalidParameterException("잘못된 권한입니다.");
+      }
     } catch (FeignException e) {
       if (e.status() == 400) {
         throw new InvalidParameterException(e.contentUTF8());
+      } else {
+        throw new InternalServerException(e.getMessage());
       }
     } catch (Exception e) {
       throw new InternalServerException("회원가입 처리 중 서버 오류가 발생했습니다.");
     }
   }
 
+  /*
+      빠른 구현을 위해서 Role 은 프론트에서 받는거로 처리
+      실제로는 메서드를 분리하고 컨트롤러를 나눠야하지만 시간관계상 해당 방식으로 진행하였습니다.
+   */
   public String signIn(LoginUserRequest request) {
-    ResponseEntity<LoginUserResponse> response = userFeignClient.findByEmail(request.getEmail());
+    ResponseEntity<LoginUserResponse> response;
+
+    if (request.getRole() == Role.CUSTOMER || request.getRole() == Role.HOST) {
+      response = userFeignClient.findByEmail(request.getEmail());
+    } else if (request.getRole() == Role.MASTER || request.getRole() == Role.MANAGER) {
+      response = userFeignClient.findAdminByEmail(request.getEmail());
+    } else {
+      throw new InvalidParameterException("잘못된 권한입니다.");
+    }
+
     LoginUserResponse signInDto = response.getBody();
     if (signInDto == null || signInDto.email() == null) {
       throw new ResourceNotFoundException("회원을 찾을수 없습니다..");
@@ -107,8 +141,7 @@ public class AuthService {
     }
 
     String encodeNewPassword = passwordEncoder.encode(newPassword);
-    userFeignClient.updatePassword(id, encodeNewPassword);
+    userFeignClient.updatePassword(new UpdatePasswordRequest(id, encodeNewPassword));
   }
 
-  
 }

--- a/src/main/java/com/fourirbnb/auth/domain/model/ApprovalStatus.java
+++ b/src/main/java/com/fourirbnb/auth/domain/model/ApprovalStatus.java
@@ -1,0 +1,5 @@
+package com.fourirbnb.auth.domain.model;
+
+public enum ApprovalStatus {
+  PENDING, APPROVED, REJECTED
+}

--- a/src/main/java/com/fourirbnb/auth/infrastructure/UserFeignClient.java
+++ b/src/main/java/com/fourirbnb/auth/infrastructure/UserFeignClient.java
@@ -2,6 +2,7 @@ package com.fourirbnb.auth.infrastructure;
 
 import com.fourirbnb.auth.presentation.dto.CreateUserInternalRequest;
 import com.fourirbnb.auth.presentation.dto.LoginUserResponse;
+import com.fourirbnb.auth.presentation.dto.UpdatePasswordRequest;
 import com.fourirbnb.auth.presentation.dto.UserInternalResponse;
 import com.fourirbnb.common.FeignInterceptor.NoAuthFeignClient;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -16,7 +17,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface UserFeignClient {
 
   @PostMapping("/internal/users/signUp")
-  ResponseEntity<Void> userSignUp(@RequestBody CreateUserInternalRequest request);
+  ResponseEntity<?> userSignUp(@RequestBody CreateUserInternalRequest request);
+
+  @PostMapping("/internal/users/saveStaging")
+  ResponseEntity<?> saveStagingRequest(@RequestBody CreateUserInternalRequest feignRequest);
 
   @GetMapping("/internal/users/email/{email}")
   ResponseEntity<LoginUserResponse> findByEmail(@PathVariable String email);
@@ -25,6 +29,11 @@ public interface UserFeignClient {
   ResponseEntity<UserInternalResponse> getEncryptedPassword(Long id);
 
   @GetMapping("/internal/updatePassword")
-  ResponseEntity<Void> updatePassword(Long id,
-      String password);
+  ResponseEntity<Void> updatePassword(@RequestBody UpdatePasswordRequest request);
+
+  @PostMapping("/internal/users/admin/signUp")
+  ResponseEntity<Void> adminSignUp(@RequestBody CreateUserInternalRequest feignRequest);
+
+  @GetMapping("/internal/users/admin/{email}")
+  ResponseEntity<LoginUserResponse> findAdminByEmail(@PathVariable String email);
 }

--- a/src/main/java/com/fourirbnb/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/fourirbnb/auth/presentation/controller/AuthController.java
@@ -2,10 +2,11 @@ package com.fourirbnb.auth.presentation.controller;
 
 
 import com.fourirbnb.auth.application.service.AuthService;
+import com.fourirbnb.auth.domain.model.Role;
 import com.fourirbnb.auth.presentation.dto.ChangePasswordRequest;
 import com.fourirbnb.auth.presentation.dto.LoginUserRequest;
-import com.fourirbnb.auth.presentation.dto.SignUpAuthRequest;
-import com.fourirbnb.auth.presentation.dto.SignUpAuthResponse;
+import com.fourirbnb.auth.presentation.dto.SignUpUserRequest;
+import com.fourirbnb.auth.presentation.dto.SignUpUserResponse;
 import com.fourirbnb.common.exception.InvalidParameterException;
 import com.fourirbnb.common.response.BaseResponse;
 import com.fourirbnb.common.security.AuthenticatedUser;
@@ -28,11 +29,22 @@ public class AuthController {
   private final AuthService authService;
 
   @PostMapping("/signUp")
-  public BaseResponse<SignUpAuthResponse> registerUser(
-      @Valid @RequestBody SignUpAuthRequest request) {
+  public BaseResponse<SignUpUserResponse> userSignUp(
+      @Valid @RequestBody SignUpUserRequest request) {
     try {
-      authService.signUp(request);
-      return BaseResponse.SUCCESS(null, "회원가입 성공", HttpStatus.CREATED.value());
+      authService.signUp(request, Role.CUSTOMER);
+      return BaseResponse.SUCCESS(null, "유저 회원가입 성공", HttpStatus.CREATED.value());
+    } catch (InvalidParameterException e) {
+      return BaseResponse.FAIL(e.getMessage(), HttpStatus.BAD_REQUEST.value());
+    }
+  }
+
+  @PostMapping("/hostSignUp")
+  public BaseResponse<SignUpUserResponse> hostSignUp(
+      @Valid @RequestBody SignUpUserRequest request) {
+    try {
+      authService.signUp(request, Role.HOST);
+      return BaseResponse.SUCCESS(null, "호스트 회원가입 성공 승인대기중", HttpStatus.CREATED.value());
     } catch (InvalidParameterException e) {
       return BaseResponse.FAIL(e.getMessage(), HttpStatus.BAD_REQUEST.value());
     }

--- a/src/main/java/com/fourirbnb/auth/presentation/controller/AuthInternalController.java
+++ b/src/main/java/com/fourirbnb/auth/presentation/controller/AuthInternalController.java
@@ -1,15 +1,45 @@
 package com.fourirbnb.auth.presentation.controller;
 
 import com.fourirbnb.auth.application.service.AuthService;
+import com.fourirbnb.auth.domain.model.Role;
+import com.fourirbnb.auth.presentation.dto.SignUpUserRequest;
+import com.fourirbnb.common.exception.InvalidParameterException;
+import com.fourirbnb.common.response.BaseResponse;
 import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping
+@RequestMapping("/internal/admin")
 @AllArgsConstructor
 public class AuthInternalController {
 
   private AuthService authService;
+
+  //MASTER
+  @PostMapping("/adminSignUp")
+  public BaseResponse<?> adminSignUp(@RequestBody SignUpUserRequest request) {
+    try {
+      authService.signUp(request, Role.MASTER);
+      return BaseResponse.SUCCESS(null, "관리자 회원가입 성공", HttpStatus.CREATED.value());
+    } catch (InvalidParameterException e) {
+      return BaseResponse.FAIL(e.getMessage(), HttpStatus.BAD_REQUEST.value());
+    }
+  }
+
+  //MANAGER
+  @PostMapping("/managerSignUp")
+  public BaseResponse<?> managerSignUp(@RequestBody SignUpUserRequest request) {
+
+    try {
+      authService.signUp(request, Role.MANAGER);
+      return BaseResponse.SUCCESS(null, "매니저 회원가입 성공 승인대기중", HttpStatus.CREATED.value());
+    } catch (InvalidParameterException e) {
+      return BaseResponse.FAIL(e.getMessage(), HttpStatus.BAD_REQUEST.value());
+    }
+  }
 
 }

--- a/src/main/java/com/fourirbnb/auth/presentation/dto/CreateUserInternalRequest.java
+++ b/src/main/java/com/fourirbnb/auth/presentation/dto/CreateUserInternalRequest.java
@@ -1,5 +1,6 @@
 package com.fourirbnb.auth.presentation.dto;
 
+import com.fourirbnb.auth.domain.model.ApprovalStatus;
 import com.fourirbnb.auth.domain.model.Role;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,4 +20,5 @@ public class CreateUserInternalRequest {
   private String phone;
   private String slackId;
   private Role role;
+  private ApprovalStatus status;
 }

--- a/src/main/java/com/fourirbnb/auth/presentation/dto/LoginUserRequest.java
+++ b/src/main/java/com/fourirbnb/auth/presentation/dto/LoginUserRequest.java
@@ -1,5 +1,6 @@
 package com.fourirbnb.auth.presentation.dto;
 
+import com.fourirbnb.auth.domain.model.Role;
 import lombok.Getter;
 
 @Getter
@@ -7,4 +8,5 @@ public class LoginUserRequest {
 
   String email;
   String password;
+  Role role;
 }

--- a/src/main/java/com/fourirbnb/auth/presentation/dto/SignUpUserRequest.java
+++ b/src/main/java/com/fourirbnb/auth/presentation/dto/SignUpUserRequest.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class SignUpAuthRequest {
+public class SignUpUserRequest {
 
   @NotBlank(message = "아이디 필수")
   @Email(message = "이메일 형식으로 입력해주세요.")
@@ -28,7 +28,7 @@ public class SignUpAuthRequest {
 
   @NotBlank(message = "사용자 이름 필수")
   private String username;
-  
+
   private String slackId;
 
   @Pattern(regexp = "^01[0-9]-\\d{3,4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")

--- a/src/main/java/com/fourirbnb/auth/presentation/dto/SignUpUserResponse.java
+++ b/src/main/java/com/fourirbnb/auth/presentation/dto/SignUpUserResponse.java
@@ -2,7 +2,7 @@ package com.fourirbnb.auth.presentation.dto;
 
 import com.fourirbnb.auth.domain.model.Role;
 
-public record SignUpAuthResponse(
+public record SignUpUserResponse(
     String email,
     String password,
     String nickname,

--- a/src/main/java/com/fourirbnb/auth/presentation/dto/UpdatePasswordRequest.java
+++ b/src/main/java/com/fourirbnb/auth/presentation/dto/UpdatePasswordRequest.java
@@ -1,0 +1,16 @@
+package com.fourirbnb.auth.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdatePasswordRequest {
+
+  private Long id;
+  private String password;
+}


### PR DESCRIPTION
## ✨ 변경 타입
* [x] 신규 기능 추가/수정
* [ ] 버그 수정
* [x] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용

* **한 줄 요약**
    * 사용자 Role에 따른 회원가입 분기 및 로그인 시 권한 기반 인증 흐름 구현

* **세부 내용**
    * 회원가입 흐름 분기 처리
        - Role 값에 따라 서로 다른 Feign API 호출
            - `CUSTOMER` → `userSignUp()` 호출하여 User로 직접 저장
            - `HOST` → `saveStagingRequest()` 호출하여 Staging에 저장
            - `MANAGER` → 동일하게 Staging에 저장
            - `MASTER` → `adminSignUp()` 호출하여 Admin으로 직접 저장

        - `SignUpUserRequest`는 공통 요청 DTO를 사용하며,
          역할은 컨트롤러 메서드에서 명시적으로 지정

        -  `role`은 컨트롤러 메서드별로 고정 처리

    * 로그인 로직 권한 기반 처리
        - 하나의 `signIn()` 메서드에서 Role 값에 따라 FeignClient 분기
            - `CUSTOMER`, `HOST` → `userFeignClient.findByEmail()`
            - `MASTER`, `MANAGER` → `userFeignClient.findAdminByEmail()`

        - 이메일 조회 결과에 따라 비밀번호 매칭 → accessToken 발급

        - 빠른 개발을 위해 로그인 시 `Role`은 요청 바디에서 함께 전달받도록 구현


    * 예외 처리 개선
        - 존재하지 않는 이메일, 비밀번호 불일치 등 다양한 예외에 대한 명확한 응답 제공
        - 잘못된 Role에 대한 요청은 명시적으로 차단 (`InvalidParameterException`)

    * FeignClient 분기 구조 개선
        - 역할 기반 API 호출 경로 정리 (`/internal/users/**`, `/internal/admin/**`)
        - 모든 회원가입/로그인 요청 흐름을 유기적으로 연결

    * 주석 및 유연성 고려
        - 현재는 DTO 통합 구조 및 역할 분기 구조를 유지
        - 추후 구조 확장 시, `AdminAuthService`, `UserAuthService` 등으로 서비스 분리 가능성 고려 가능
